### PR TITLE
timezone

### DIFF
--- a/services/api/src/lib/analytics.js
+++ b/services/api/src/lib/analytics.js
@@ -78,7 +78,7 @@ async function timeSeries(index, operation, field, options = undefined, returnSe
   };
   if (options.range && options.range[dateField]) {
     date_histogram.extended_bounds = {};
-    const { from, to, gte, gt, lte, lt } = options.range[dateField];
+    const { from, to, gte, gt, lte, lt, time_zone } = options.range[dateField];
     if (from) {
       date_histogram.extended_bounds.min = from;
     } else if (gte) {
@@ -92,6 +92,10 @@ async function timeSeries(index, operation, field, options = undefined, returnSe
       date_histogram.extended_bounds.max = lte;
     } else if (lt) {
       date_histogram.extended_bounds.max = lt;
+    }
+
+    if (time_zone) {
+      date_histogram.time_zone = timeZone;
     }
   }
 


### PR DESCRIPTION
This is just to ensure we consistent, with range operator.

The time zone is needed for all endpoints that does anything with time ranges (due to from and to can be using date_math, e.g. "now-1h/d").

The time series is the only endpoint where this doesn't work as expected.

We should (at some point) standardize the time range options, so we its not a direct port of ES format + lock down the joi definition.